### PR TITLE
Allow pyqt as a valid QT_API env value

### DIFF
--- a/AnyQt/_api.py
+++ b/AnyQt/_api.py
@@ -45,7 +45,12 @@ def comittoapi(api):
 if AnyQt.__SELECTED_API is not None:
     comittoapi(AnyQt.__SELECTED_API)
 elif "QT_API" in os.environ:
-    comittoapi(os.environ["QT_API"].lower())
+    api = os.environ["QT_API"].lower()
+    if api == "pyqt":
+        # Qt.py allows both pyqt4 and pyqt to specify PyQt4.
+        # When run from anaconda-navigator, pyqt is used.
+        api = "pyqt4"
+    comittoapi(api)
 else:
     # Check sys.modules for existing imports
     __existing = None


### PR DESCRIPTION
When Orange is run from anaconda-navigator, QT_API value is set to pyqt (which is a valid value in Qt.py), causing a crash

```
  File "/Users/anze/anaconda3/bin/orange-canvas", line 4, in <module>
    import Orange.canvas.__main__
  File "/Users/anze/anaconda3/lib/python3.5/site-packages/Orange/canvas/__main__.py", line 20, in <module>
    from AnyQt.QtGui import QFont, QColor, QDesktopServices
  File "/Users/anze/anaconda3/lib/python3.5/site-packages/AnyQt/QtGui.py", line 1, in <module>
    from . import _api
  File "/Users/anze/anaconda3/lib/python3.5/site-packages/AnyQt/_api.py", line 49, in <module>
    comittoapi(os.environ["QT_API"].lower())
  File "/Users/anze/anaconda3/lib/python3.5/site-packages/AnyQt/_api.py", line 33, in comittoapi
    assert api in [QT_API_PYQT5, QT_API_PYQT4, QT_API_PYSIDE]
```
