### PR TITLE
QtGui: Make WheelEvent >=PyQt5.12 constructor work <PyQt5.12

### DIFF
--- a/AnyQt/QtGui.py
+++ b/AnyQt/QtGui.py
@@ -136,6 +136,45 @@ __Qt4_QtGui = [
 
 if _api.USED_API == _api.QT_API_PYQT5:
     from PyQt5.QtGui import *
+    from PyQt5.QtCore import PYQT_VERSION as _PYQT_VERSION
+
+    if _PYQT_VERSION < 0x50c00:  # 5.12.0
+
+        class WheelEvent(QWheelEvent):
+            from PyQt5.QtCore import (QPointF as _QPointF,
+                                      QPoint as _QPoint,
+                                      Qt as _Qt)
+
+            _constructor_signature = \
+                ((_QPointF, _QPoint),
+                 (_QPointF, _QPoint),
+                 (_QPoint,),
+                 (_QPoint,),
+                 (_Qt.MouseButtons, _Qt.MouseButton),
+                 (_Qt.KeyboardModifiers, _Qt.KeyboardModifier),
+                 (_Qt.ScrollPhase,),
+                 (bool,),
+                 (_Qt.MouseEventSource,))
+
+            def __init__(self, *args):
+                sig = WheelEvent._constructor_signature
+                if len(args) == len(sig) and \
+                        all(any(isinstance(a, t) for t in ts)
+                            for a, ts in zip(args, sig)):
+                    angleDelta = args[3]
+                    if abs(angleDelta.x()) > abs(angleDelta.y()):
+                        orientation = 0x1  # horizontal
+                        delta = angleDelta.x()
+                    else:
+                        orientation = 0x2  # vertical
+                        delta = angleDelta.y()
+                    args = args[:4] + \
+                           (delta, orientation) + \
+                           args[4:7] + (args[8], args[7])
+                super().__init__(*args)
+
+        QWheelEvent = WheelEvent
+
 elif _api.USED_API == _api.QT_API_PYQT4:
     import PyQt4.QtGui as _QtGui
     globals().update(


### PR DESCRIPTION
PyQt5.12 obsoleted QWheelEvent's old constructors, changing how the scrolling calculation works. This makes it hard to write custom QWheelEvent across these versions.

This PR adds support for transcribing the new constructor into the old one, similar to how QWheelEvents are handled in Qt source code. See https://code.qt.io/cgit/qt/qtbase.git/tree/src/widgets/widgets/qabstractscrollarea.cpp?h=dev#n1201.

So you're transforming this signature:
```
QWheelEvent(Union[QPointF, QPoint], Union[QPointF, QPoint], QPoint, QPoint, Union[Qt.MouseButtons, Qt.MouseButton], Union[Qt.KeyboardModifiers, Qt.KeyboardModifier], Qt.ScrollPhase, bool, source: Qt.MouseEventSource = Qt.MouseEventNotSynthesized)
```
Into this one:
```
QWheelEvent(Union[QPointF, QPoint], Union[QPointF, QPoint], QPoint, QPoint, int, Qt.Orientation, Union[Qt.MouseButtons, Qt.MouseButton], Union[Qt.KeyboardModifiers, Qt.KeyboardModifier], Qt.ScrollPhase, Qt.MouseEventSource, bool)
```

Admittedly, this implementation does not account for the last argument of the most recent constructor signature to be optional.

(if you think the way this is written is ugly, let me know, I'll adjust it however you best see fit)
